### PR TITLE
Class ReflectedBeamOptions

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -14,6 +14,7 @@ Notes for major and minor releases. Notes for patch releases are referred.
 
 **Of interest to the Developer:**
 
+- PR #24 Class ReflectedBeamOptions to reuse when saving to diferent file formats
 - PR #23 Class DirectBeamOptions to reuse when saving to diferent file formats
 - PR #22 SampleLogs class to reduce boilerplate code and make the code more pythonic
 - PR #21 Enum DataType substitutes expressions involving integer values to improved understanding of the source

--- a/src/mr_reduction/reflectivity_output.py
+++ b/src/mr_reduction/reflectivity_output.py
@@ -6,7 +6,7 @@ Write reflectivity output file
 # standard imports
 import math
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import List, Optional
 
 # third party imports
@@ -15,7 +15,7 @@ import mantid
 # mr_reduction imports
 import mr_reduction
 from mr_reduction.runpeak import RunPeakNumber
-from mr_reduction.simple_utils import SampleLogs
+from mr_reduction.simple_utils import SampleLogs, workspace_handle
 from mr_reduction.types import MantidWorkspace
 
 
@@ -104,6 +104,143 @@ class DirectBeamOptions:
         for option in self.options:
             value = getattr(self, option)
             if isinstance(value, (bool, str)):
+                clean_dict[option] = "%8s" % value
+            else:
+                clean_dict[option] = "%8g" % value
+
+        template = "# %s\n" % "  ".join(["{%s}" % p for p in self.options])
+        return template.format(**clean_dict)
+
+
+@dataclass
+class ReflectedBeamOptions:
+    scale: float
+    P0: int
+    PN: int
+    x_pos: float  # peak center
+    x_width: float  # peak width
+    y_pos: float
+    y_width: float
+    bg_pos: float
+    bg_width: float
+    fan: bool
+    dpix: float
+    tth: float
+    number: str
+    DB_ID: int
+    File: str
+    """two-theta offset to be applied when saving the options to a file later to be read by QuickNXS"""
+    tth_offset: float = field(repr=False, default=0.0)
+
+    @classmethod
+    def dat_header(cls) -> str:
+        """Header for the direct beam options in the *_autoreduced.dat file"""
+        options = cls.__dataclass_fields__
+        del options["tth_offset"]
+        return "# [Data Runs]\n# %s\n" % "  ".join(["%8s" % option for option in options])
+
+    @staticmethod
+    def filename(input_workspace: MantidWorkspace) -> str:
+        """
+        Generate a filename for the given Mantid workspace.
+
+        This method retrieves the filename from the Mantid workspace's run object.
+        If the filename ends with 'nxs.h5', it modifies the filename to be compatible
+        with QuickNXS by replacing 'nexus' with 'data' and changing the extension to '_histo.nxs'.
+        If the workspace is live data and does not have a filename, it returns 'live data'.
+        """
+        sample_logs = SampleLogs(input_workspace)
+        if "Filename" in sample_logs:
+            filename = sample_logs["Filename"]
+            if filename.endswith("nxs.h5"):
+                filename = filename.replace("nexus", "data")
+                filename = filename.replace(".nxs.h5", "_histo.nxs")
+        else:
+            filename = "live data"  # For live data, we might not have a file name
+        return filename
+
+    @staticmethod
+    def two_theta_offset(input_workspace: MantidWorkspace) -> float:
+        """two-theta offset for compatibility with QuickNXS.
+
+        For some reason, the tth value that QuickNXS expects is offset.
+        It seems to be because that same offset is applied later in the QuickNXS calculation.
+        """
+        ws = workspace_handle(input_workspace)
+        sample_logs = SampleLogs(input_workspace)
+        scatt_pos = sample_logs["specular_pixel"]
+        det_distance = sample_logs.mean("SampleDetDis")
+        # Check units
+        if sample_logs.property("SampleDetDis").units not in ["m", "meter"]:
+            det_distance /= 1000.0
+        direct_beam_pix = sample_logs.mean("DIRPIX")
+        # Get pixel size from instrument properties
+        if ws.getInstrument().hasParameter("pixel-width"):
+            pixel_width = float(ws.getInstrument().getNumberParameter("pixel-width")[0]) / 1000.0
+        else:
+            pixel_width = 0.0007
+
+        return -((direct_beam_pix - scatt_pos) * pixel_width) / det_distance * 180.0 / math.pi
+
+    @classmethod
+    def from_workspace(cls, input_workspace: MantidWorkspace, direct_beam_counter=1) -> "ReflectedBeamOptions":
+        """Create an instance of ReflectedBeamOptions from a workspace.
+
+        Parameters
+        ----------
+        input_workspace : MantidWorkspace
+            The Mantid workspace from which to create the ReflectedBeamOptions instance.
+        direct_beam_counter : int, optional
+            The counter for the direct beam associated to this reflected beam, by default 1.
+        """
+        sample_logs = SampleLogs(input_workspace)
+
+        peak_min = sample_logs["scatt_peak_min"]
+        peak_max = sample_logs["scatt_peak_max"]
+        bg_min = sample_logs["scatt_bg_min"]
+        bg_max = sample_logs["scatt_bg_max"]
+        low_res_min = sample_logs["scatt_low_res_min"]
+        low_res_max = sample_logs["scatt_low_res_max"]
+        filename = cls.filename(input_workspace)
+        scatt_pos = sample_logs["specular_pixel"]
+
+        options = ReflectedBeamOptions(
+            scale=1,
+            P0=0,
+            PN=0,
+            x_pos=scatt_pos,
+            x_width=peak_max - peak_min + 1,
+            y_pos=(low_res_max + low_res_min) / 2.0,
+            y_width=low_res_max - low_res_min + 1,
+            bg_pos=(bg_min + bg_max) / 2.0,
+            bg_width=bg_max - bg_min + 1,
+            fan=sample_logs["constant_q_binning"],
+            dpix=sample_logs.mean("DIRPIX"),
+            tth=sample_logs["two_theta"],
+            number=sample_logs["run_number"],
+            DB_ID=direct_beam_counter,
+            File=filename,
+        )
+
+        # two-theta offset for compatibility with QuickNXS
+        options.tth_offset = cls.two_theta_offset(input_workspace)
+
+        return options
+
+    @property
+    def options(self) -> List[str]:
+        """List of option names, excluding the two-theta offset"""
+        return self.__dataclass_fields__
+
+    @property
+    def as_dat(self) -> str:
+        """Formatted string representation of the DirectBeamOptions suitable for an *_autoreduced.dat file"""
+        clean_dict = {}
+        for option in self.options:
+            value = getattr(self, option)
+            if option == "tth":
+                value += self.tth_offset
+            if isinstance(value, str):
                 clean_dict[option] = "%8s" % value
             else:
                 clean_dict[option] = "%8g" % value

--- a/src/mr_reduction/reflectivity_output.py
+++ b/src/mr_reduction/reflectivity_output.py
@@ -40,6 +40,25 @@ class DirectBeamOptions:
     File: str  # normalization run in the re-processed and legacy-compatible, readable by QuickNXS
 
     @staticmethod
+    def option_names() -> List[str]:
+        """List of option names in the order expected for a QuickNXS output file"""
+        return [
+            "DB_ID",
+            "P0",
+            "PN",
+            "x_pos",
+            "x_width",
+            "y_pos",
+            "y_width",
+            "bg_pos",
+            "bg_width",
+            "dpix",
+            "tth",
+            "number",
+            "File",
+        ]
+
+    @staticmethod
     def from_workspace(input_workspace: MantidWorkspace, direct_beam_counter=1) -> Optional["DirectBeamOptions"]:
         """Create an instance of DirectBeamOptions from a workspace.
 
@@ -93,22 +112,17 @@ class DirectBeamOptions:
         return "# [Direct Beam Runs]\n# %s\n" % "  ".join(["%8s" % field for field in cls.__dataclass_fields__])
 
     @property
-    def options(self) -> List[str]:
-        """List of option names"""
-        return self.__dataclass_fields__
-
-    @property
     def as_dat(self) -> str:
         """ "Formatted string representation of the DirectBeamOptions suitable for an *_autoreduced.dat file"""
         clean_dict = {}
-        for option in self.options:
-            value = getattr(self, option)
+        for name in self.option_names():
+            value = getattr(self, name)
             if isinstance(value, (bool, str)):
-                clean_dict[option] = "%8s" % value
+                clean_dict[name] = "%8s" % value
             else:
-                clean_dict[option] = "%8g" % value
+                clean_dict[name] = "%8g" % value
 
-        template = "# %s\n" % "  ".join(["{%s}" % p for p in self.options])
+        template = "# %s\n" % "  ".join(["{%s}" % p for p in self.option_names()])
         return template.format(**clean_dict)
 
 
@@ -131,6 +145,27 @@ class ReflectedBeamOptions:
     File: str
     """two-theta offset to be applied when saving the options to a file later to be read by QuickNXS"""
     tth_offset: float = field(repr=False, default=0.0)
+
+    @staticmethod
+    def option_names() -> List[str]:
+        """List of option names, excluding the two-theta offset, in the order expected for a QuickNXS output file"""
+        return [
+            "scale",
+            "P0",
+            "PN",
+            "x_pos",
+            "x_width",
+            "y_pos",
+            "y_width",
+            "bg_pos",
+            "bg_width",
+            "fan",
+            "dpix",
+            "tth",
+            "number",
+            "DB_ID",
+            "File",
+        ]
 
     @classmethod
     def dat_header(cls) -> str:
@@ -228,24 +263,19 @@ class ReflectedBeamOptions:
         return options
 
     @property
-    def options(self) -> List[str]:
-        """List of option names, excluding the two-theta offset"""
-        return self.__dataclass_fields__
-
-    @property
     def as_dat(self) -> str:
-        """Formatted string representation of the DirectBeamOptions suitable for an *_autoreduced.dat file"""
+        """Formatted string representation of the ReflectedBeamOptions suitable for an *_autoreduced.dat file"""
         clean_dict = {}
-        for option in self.options:
-            value = getattr(self, option)
-            if option == "tth":
+        for name in self.option_names():
+            value = getattr(self, name)
+            if name == "tth":
                 value += self.tth_offset
             if isinstance(value, str):
-                clean_dict[option] = "%8s" % value
+                clean_dict[name] = "%8s" % value
             else:
-                clean_dict[option] = "%8g" % value
+                clean_dict[name] = "%8g" % value
 
-        template = "# %s\n" % "  ".join(["{%s}" % p for p in self.options])
+        template = "# %s\n" % "  ".join(["{%s}" % p for p in self.option_names()])
         return template.format(**clean_dict)
 
 

--- a/tests/unit/mr_reduction/test_reflectivity_output.py
+++ b/tests/unit/mr_reduction/test_reflectivity_output.py
@@ -140,7 +140,12 @@ def test_write_reflectivity(mock_filesystem, data_server):
     obtained = open(output_file).readlines()[4:]
     expected = open(data_server.path_to("REF_M_29160_2_Off_Off_autoreduce.dat")).readlines()[4:]
     for obtained_line, expected_line in zip(obtained, expected):
-        assert obtained_line == expected_line
+        if ("REF_M_29137_histo.nxs" in obtained_line) or ("REF_M_29160_histo.nxs" in obtained_line):
+            obtained_items = obtained_line.split()[:-1]  # remove the last item which is the absolute file path
+            expected_items = expected_line.split()[:-1]
+            assert obtained_items == expected_items
+        else:
+            assert obtained_line == expected_line
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description of work:
The purpose of this `dataclass` is to store options that can be used to write the reflectivity file to QuickNXS format (already implemented) or ORSO format (to be implemented)

Check all that apply:
- [x] added [release notes](https://mr-reduction.readthedocs.io/en/latest/releases.html)
(if not, provide an explanation in the work description)
- ~updated documentation~
- [x] Source added/refactored
- [x] Added unit tests
- ~Added integration tests~

**References:**
- Links to IBM EWM items: [8489](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=8489)

## Manual test for the reviewer
Just make sure that `pytest -n 1 tests/` succeeds on a local repository

## Check list for the reviewer
- [ ] [release notes](https://mr-reduction.readthedocs.io/en/latest/releases.html)
updated, or an explanation is provided as to why release notes are unnecessary
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
