### PR TITLE
fix extracting the run number in the template script

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -10,6 +10,7 @@ Notes for major and minor releases. Notes for patch releases are referred.
 
 **Of interest to the User**:
 
+- PR #26 Fix extracting the run number in the autoreduction template
 - PR #9 Add the capability to autoreduce two peaks from the same run
 
 **Of interest to the Developer:**

--- a/src/mr_autoreduce/reduce_REF_M.py.template
+++ b/src/mr_autoreduce/reduce_REF_M.py.template
@@ -130,7 +130,7 @@ def main():
     file_path = args.report_file
     if file_path and os.path.basename(file_path) == file_path:
         file_path = os.path.join(args.outdir, file_path)
-    run_number = re.search(r'REF_M_\d+', args.events_file).group(0)
+    run_number = re.search(r'REF_M_(\d+)', args.events_file).group(1)
     upload_html_report(reports, publish=(not args.no_publish), run_number=run_number, report_file=file_path)
 
     # Check if the auto-reduce data has been saved to the canonical IPTS-XXXXX/shared/autoreduce directory


### PR DESCRIPTION
## Description of work:

Check all that apply:
- [x] added [release notes](https://mr-reduction.readthedocs.io/en/latest/releases.html)
(if not, provide an explanation in the work description)
- [ ] ~updated documentation~
- [x] Source added/refactored
- [ ] ~Added unit tests~
- [ ] ~Added integration tests~
- [ ] 
**References:**
- Links to IBM EWM items:
- Links to related issues or pull requests:

## Manual test for the reviewer
(Instructions for testing here)

## Check list for the reviewer
- [ ] [release notes](https://mr-reduction.readthedocs.io/en/latest/releases.html)
updated, or an explanation is provided as to why release notes are unnecessary
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
