### PR TITLE
Saving all cross-sections for one run in one ORSO-formatted file

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -9,6 +9,7 @@ Notes for major and minor releases. Notes for patch releases are referred.
 (date of release, format YYYY-MM-DD)
 
 **Of interest to the User**:
+- PR #33 Saving all cross-sections for one run in one ORSO-formatted file
 
 **Of interest to the Developer:**
 

--- a/src/mr_reduction/scripts/nexus_to_orso.py
+++ b/src/mr_reduction/scripts/nexus_to_orso.py
@@ -3,6 +3,7 @@
 
 # standard imports
 import argparse
+import os
 
 # third party imports
 import argcomplete
@@ -13,17 +14,26 @@ from mr_reduction.io_orso import write_orso
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Convert a Nexus file resulting from autoreduction to *.ort ORSO")
-    parser.add_argument("--nexus", required=True, help="Path to the input Nexus file")
+    parser = argparse.ArgumentParser(
+        description="Convert one or more Nexus files resulting from autoreduction to a *.ort ORSO files"
+    )
+    parser.add_argument("--nexus", required=True, help="Path to the input Nexus file(s)")
     parser.add_argument("--ort", required=True, help="Path to the output *.ort ORSO file")
     argcomplete.autocomplete(parser)
     args = parser.parse_args()
 
-    # Load the Nexus file
-    reflectivity_workspace = LoadNexusProcessed(args.nexus)
+    # Load the Nexus file(s)
+    workspace_list = []
+    valid_suffix = "_autoreduce.nxs.h5"
+    for nexus_path in args.nexus.split():
+        if nexus_path.endswith(valid_suffix) is False:
+            raise ValueError(f"Input file {nexus_path} is not a valid Nexus autoreduced file")
+        workspace_name = os.path.basename(nexus_path).removesuffix(valid_suffix)
+        LoadNexusProcessed(Filename=nexus_path, OutputWorkspace=workspace_name)
+        workspace_list.append(workspace_name)
 
     # Write the ORSO file
-    write_orso([reflectivity_workspace], args.ort)
+    write_orso(workspace_list, args.ort)
 
 
 if __name__ == "__main__":

--- a/tests/unit/mr_reduction/test_io_orso.py
+++ b/tests/unit/mr_reduction/test_io_orso.py
@@ -1,13 +1,45 @@
+# standard library imports
 import os
 from typing import List
 
-import mr_reduction
+# third-party imports
 import pytest
-from mantid.simpleapi import LoadNexusProcessed
+from mantid.simpleapi import LoadNexusProcessed, mtd
+
+# mr_reduction imports
 from mr_reduction.io_orso import write_orso
 from numpy.testing import assert_almost_equal
 from orsopy.fileio.base import Column, ErrorColumn
 from orsopy.fileio.orso import Orso, OrsoDataset, load_orso
+
+
+def assert_columns(datasets: List[OrsoDataset]):
+    """Test-helper function, assert that each dataset in the list has the expected columns"""
+    for dataset in datasets:
+        info: Orso = dataset.info
+        assert len(info.columns) == 6
+        for i, (label, coltype) in enumerate(
+            [
+                ("Qz", Column),
+                ("R", Column),
+                ("sR", ErrorColumn),
+                ("sQz", ErrorColumn),
+                ("theta", Column),
+                ("stheta", ErrorColumn),
+            ]
+        ):
+            assert isinstance(info.columns[i], coltype)
+            assert info.columns[i].name == label
+
+
+def assert_instrument_settings(datasets: List[OrsoDataset], thetas, wavelengths, polarizations):
+    """Test-helper function, assert that each dataset in the list has the expected instrument settings"""
+    for i, dataset in enumerate(datasets):
+        info: Orso = dataset.info
+        instrument_settings = info.data_source.measurement.instrument_settings
+        assert_almost_equal(instrument_settings.incident_angle.magnitude, thetas[i], decimal=3)
+        assert_almost_equal(instrument_settings.wavelength.min, wavelengths[i], decimal=3)
+        assert instrument_settings.polarization.value == polarizations[i]
 
 
 def test_write_orso_output_file_extension():
@@ -16,7 +48,8 @@ def test_write_orso_output_file_extension():
 
 
 @pytest.mark.datarepo()
-def test_write_orso(mock_filesystem, data_server):
+def test_write_orso_single_cross_section(mock_filesystem, data_server):
+    """write a single cross-section workspace to an ORSO file and check its contents"""
     reflectivity_workspace = LoadNexusProcessed(data_server.path_to("REF_M_29160_2_Off_Off_autoreduce.nxs.h5"))
     output_file = os.path.join(mock_filesystem.tempdir, "REF_M_29160_2_Off_Off_autoreduce.ort")
     write_orso([reflectivity_workspace], output_file)
@@ -25,30 +58,30 @@ def test_write_orso(mock_filesystem, data_server):
     #
     datasets: List[OrsoDataset] = load_orso(output_file)
     assert len(datasets) == 1
-    dataset = datasets[0]
-    assert dataset.data.shape == (35, 6)
-    info: Orso = dataset.info
-    assert len(info.columns) == 6
-    for i, (label, coltype) in enumerate(
-        [
-            ("Qz", Column),
-            ("R", Column),
-            ("sR", ErrorColumn),
-            ("sQz", ErrorColumn),
-            ("theta", Column),
-            ("stheta", ErrorColumn),
-        ]
-    ):
-        assert isinstance(info.columns[i], coltype)
-        assert info.columns[i].name == label
-    assert info.reduction.software.version == mr_reduction.__version__
-    assert "MagnetismReflectometryReduction" in info.reduction.call
+    assert_columns(datasets)
+    assert_instrument_settings(datasets, thetas=[0.015], wavelengths=[2.7], polarizations=["pp"])
 
-    # assert instrument settings
-    instrument_settings = info.data_source.measurement.instrument_settings
-    assert_almost_equal(instrument_settings.incident_angle.magnitude, 0.015, decimal=3)
-    assert_almost_equal(instrument_settings.wavelength.min, 2.7, decimal=3)
-    assert instrument_settings.polarization.value == "pp"
+
+@pytest.mark.datarepo()
+def test_write_orso_run_cross_sections(mock_filesystem, data_server):
+    workspace_list = []
+    for cross_section in ["Off_Off", "On_Off"]:
+        workspace = mtd.unique_hidden_name()
+        LoadNexusProcessed(
+            Filename=data_server.path_to(f"REF_M_42535_1_{cross_section}_autoreduce.nxs.h5"), OutputWorkspace=workspace
+        )
+        workspace_list.append(workspace)
+    output_file = os.path.join(mock_filesystem.tempdir, "REF_M_29160_2_Off_Off_autoreduce.ort")
+    write_orso(workspace_list, output_file)
+    #
+    # load the ORSO file and check its contents
+    #
+    datasets: List[OrsoDataset] = load_orso(output_file)
+    assert len(datasets) == 2
+    assert set([dataset.info.data_set for dataset in datasets]) == {"Off_Off", "On_Off"}
+    assert [dataset.data.shape for dataset in datasets] == [(52, 6), (52, 6)]
+    assert_columns(datasets)
+    assert_instrument_settings(datasets, thetas=[0.007, 0.007], wavelengths=[2.55, 2.55], polarizations=["po", "mo"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description of work:

Check all that apply:
- [x] added [release notes](https://mr-reduction.readthedocs.io/en/latest/releases.html)
(if not, provide an explanation in the work description)
- [ ] ~updated documentation~
- [x] Source added/refactored
- [x] Added unit tests
- [ ] ~Added integration tests~

**References:**
- Links to IBM EWM items: [9036](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=9036)

## Manual test for the reviewer
Install in editable mode (`pip install -e ./`) so that you can run script `nexus_to_orso` :

```
cd /path/to/MagnetismReflectometer/mr_reduction-feature/tests/mr_reduction-data/
nexus_to_orso --nexus "REF_M_42535_1_Off_Off_autoreduce.nxs.h5 REF_M_42535_1_On_Off_autoreduce.nxs.h5" --ort /tmp/REF_M_42535.ort
```
The resulting file should be loadable in `refl1d`

## Check list for the reviewer
- [ ] [release notes](https://mr-reduction.readthedocs.io/en/latest/releases.html)
updated, or an explanation is provided as to why release notes are unnecessary
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
