### PR TITLE
Purge the cross-section filtering table of negative relative times to the start of the run

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -16,6 +16,7 @@ Notes for major and minor releases. Notes for patch releases are referred to the
    - PR #41: bugfix for runs containing logs with time entries predating the start of the run
 
    **Of interest to the Developer:**
+   - PR #50: Purge the cross-section filtering table of negative relative times to the start of the run
    - PR #45: Document how to deploy updates to the live reduction service
    - PR #44: Documentation on how to use StartLiveData algorithm
    - PR #43: Update livereduce.conf file

--- a/src/mr_reduction/filter_events.py
+++ b/src/mr_reduction/filter_events.py
@@ -86,18 +86,17 @@ class MRFilterCrossSections(PythonAlgorithm):
         # Keep track of when we have a fully specified state
         specified = [not has_polarizer, not has_analyzer]
 
-        # Find first entry with a time equal to or greater than start_time
-        index_begin = 0
-        for i, (entry_time, *_) in enumerate(change_list):
-            if entry_time >= start_time:
-                index_begin = i
-                break
-
-        for item in change_list[index_begin:]:
+        for item in change_list:
             # We have a change of state, add an entry for the state that just ended
             if specified[0] and specified[1] and not current_state[2] and not current_state[3]:
                 xs = "%s_%s" % ("On" if current_state[0] else "Off", "On" if current_state[1] else "Off")
-                split_table_ws.addRow([int(current_state_t0 - start_time) * 1e-9, (item[0] - start_time) * 1e-9, xs])
+                start = int(current_state_t0 - start_time)
+                stop = item[0] - start_time
+                if start < 0 and stop <= 0:
+                    continue  # don't consider time-windows before the start time
+                if start < 0 < stop:
+                    start = 0.0  # keep only the fragment of the time-window after the start time
+                split_table_ws.addRow([start * 1e-9, stop * 1e-9, xs])
 
             # Now update the current state
             for i in range(len(current_state)):

--- a/tests/integration/test_filter_events.py
+++ b/tests/integration/test_filter_events.py
@@ -21,7 +21,7 @@ def test_MRFilterCrossSections(data_server):
         AnaVeto=ANA_VETO,
         CrossSectionWorkspaces="44316",
     )
-    assert [workspace.getNumberEvents() for workspace in workspace_group] == [281213, 265042]
+    assert [workspace.getNumberEvents() for workspace in workspace_group] == [289972, 281213]
 
 
 if __name__ == "__main__":

--- a/tests/unit/mr_reduction/test_filter_events.py
+++ b/tests/unit/mr_reduction/test_filter_events.py
@@ -30,9 +30,9 @@ class TestMRFilterCrossSections:
             changes, start_time=1114104876000000000, has_polarizer=True, has_analyzer=False
         )
         assert table.row(0) == {
-            "start": pytest.approx(73.9, abs=0.1),
-            "stop": pytest.approx(148.7, abs=0.1),
-            "target": "On_Off",
+            "start": pytest.approx(0.0, abs=0.1),
+            "stop": pytest.approx(73.9, abs=0.1),
+            "target": "Off_Off",
         }
 
     @pytest.mark.datarepo()
@@ -57,8 +57,8 @@ class TestMRFilterCrossSections:
 
         filter_obj.filter_cross_sections(file_path="")
         workspace_group = filter_obj.getProperty("CrossSectionWorkspaces").value
-        assert list(workspace_group.getNames()) == ["44316_On_Off", "44316_Off_Off"]
-        assert [workspace.getNumberEvents() for workspace in workspace_group] == [281213, 265042]
+        assert list(workspace_group.getNames()) == ["44316_Off_Off", "44316_On_Off"]
+        assert [workspace.getNumberEvents() for workspace in workspace_group] == [289972, 281213]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description of work:

Check all that apply:
- [x] added [release notes](https://mr-reduction.readthedocs.io/en/latest/releases.html)
(if not, provide an explanation in the work description)
- [ ] ~updated documentation~
- [x] Source added/refactored
- [ ] ~Added unit tests~
- [ ] ~Added integration tests~

**References:**
- Links to IBM EWM items: [10988](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=10988)

## :warning: ~Manual test for the reviewer~

## Check list for the reviewer
- [ ] [release notes](https://mr-reduction.readthedocs.io/en/latest/releases.html)
updated, or an explanation is provided as to why release notes are unnecessary
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
