### PR TITLE
Autoreduction will not save the current "REF_M_*_combined.py" script anymore

### DIFF
--- a/tests/integration/test_mr_reduction.py
+++ b/tests/integration/test_mr_reduction.py
@@ -37,7 +37,6 @@ class TestReduction:
             "REF_M_29160_2.ort",
             "REF_M_29160_2_combined.ort",
             "REF_M_29160_2_partial.py",
-            "REF_M_29160_2_tunable_combined.py",
         ]:
             assert os.path.isfile(os.path.join(mock_filesystem.tempdir, file))
         questor = io_orso.Questor(filepath=os.path.join(mock_filesystem.tempdir, "REF_M_29160_2_combined.ort"))
@@ -73,7 +72,6 @@ class TestReduction:
             "REF_M_28142_combined.ort",
             "REF_M_28142_combined.py",
             "REF_M_28142_partial.py",
-            "REF_M_28142_tunable_combined.py",
         ]:
             assert os.path.isfile(os.path.join(mock_filesystem.tempdir, file)), f"File {file} doesn't exist"
         questor = io_orso.Questor(filepath=os.path.join(mock_filesystem.tempdir, "REF_M_28142_combined.ort"))
@@ -125,7 +123,6 @@ class TestReduction:
             "REF_M_41445_combined.py",
             "REF_M_41447.json",
             "REF_M_41445_Off_Off_combined.dat",
-            "REF_M_41445_tunable_combined.py",
         ]:
             assert os.path.isfile(os.path.join(mock_filesystem.tempdir, file)), f"File {file} doesn't exist"
         questor = io_orso.Questor(filepath=os.path.join(mock_filesystem.tempdir, "REF_M_41447.ort"))
@@ -188,7 +185,6 @@ class TestReduction:
                 "_combined.py",
                 "_Off_Off_combined.dat",
                 "_On_Off_combined.dat",
-                "_tunable_combined.py",
                 "_combined.ort",
             ]:
                 file = f"REF_M_42535_{sn}{suffix}"

--- a/tests/integration/test_reduce_REF_M_live_post_proc.py
+++ b/tests/integration/test_reduce_REF_M_live_post_proc.py
@@ -84,7 +84,6 @@ def test_main(mock_filesystem, data_server, browser, autoreduction_script):
             "_Off_Off_combined.dat",
             "_On_Off_combined.dat",
             "_combined.ort",  # ORSO ASCII format
-            "_tunable_combined.py",
         ]:
             file = f"REF_M_42535_{peak_number}{suffix}"
             assert os.path.isfile(os.path.join(mock_filesystem.tempdir, file)), f"{file} doesn't exist"
@@ -130,7 +129,6 @@ def test_main_with_negative_relative_times(mock_filesystem, data_server, autored
         "_On_Off_combined.dat",
         ".ort",
         "_partial.py",
-        "_tunable_combined.py",
     ]:
         file_path = os.path.join(mock_filesystem.tempdir, f"REF_M_44316{suffix}")
         output_files.append(file_path)

--- a/tests/integration/test_reduce_REF_M_run.py
+++ b/tests/integration/test_reduce_REF_M_run.py
@@ -125,7 +125,7 @@ def test_reduce_REF_M_run(mock_filesystem, data_server):
     # assert stitched files have been produced (file names use run 42535 because this is
     # the first in the sequence of experiments encompassing run 42535 through 42538)
     for sn in (1, 2):
-        for suffix in ["_combined.py", "_Off_Off_combined.dat", "_On_Off_combined.dat", "_tunable_combined.py"]:
+        for suffix in ["_combined.py", "_Off_Off_combined.dat", "_On_Off_combined.dat"]:
             file = f"REF_M_42535_{sn}{suffix}"
             assert os.path.isfile(os.path.join(mock_filesystem.tempdir, file)), f"{file} doesn't exist"
 

--- a/tests/integration/test_template.py
+++ b/tests/integration/test_template.py
@@ -67,7 +67,7 @@ def test_template(mock_filesystem, data_server, autoreduction_script):
     # assert stitched files have been produced (file names use run 42535 because this is
     # the first in the sequence of experiments encompassing run 42535 through 42538)
     for sn in (1, 2):
-        for suffix in ["_combined.py", "_Off_Off_combined.dat", "_On_Off_combined.dat", "_tunable_combined.py"]:
+        for suffix in ["_combined.py", "_Off_Off_combined.dat", "_On_Off_combined.dat"]:
             file = f"REF_M_42535_{sn}{suffix}"
             assert os.path.isfile(os.path.join(mock_filesystem.tempdir, file)), f"{file} doesn't exist"
 


### PR DESCRIPTION
## Description of work:

Check all that apply:
- [x] added [release notes](https://mr-reduction.readthedocs.io/en/latest/releases.html)
(if not, provide an explanation in the work description)
- [ ] updated documentation
- [x] Source added/refactored
- [x] Refactored unit tests
- [x] Refactored integration tests

**References:**
- Links to IBM EWM items: [10608](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=10608)

## :warning: Manual test for the reviewer
(Instructions for testing here)

## Check list for the reviewer
- [ ] [release notes](https://mr-reduction.readthedocs.io/en/latest/releases.html)
updated, or an explanation is provided as to why release notes are unnecessary
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
