### PR TITLE
ROI1 is used for peak, and ROI2 for background

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -13,6 +13,7 @@ Notes for major and minor releases. Notes for patch releases are referred to the
    **Of interest to the User:**
 
    **Of interest to the Developer:**
+   - PR #57: ROI1 is used for peak, and ROI2 for background
    - PR #55: Refactor MRInspectData as module inspect_data
 ..
 

--- a/src/mr_reduction/inspect_data.py
+++ b/src/mr_reduction/inspect_data.py
@@ -417,7 +417,7 @@ class DataInspector(object):
 
         # Inspect the ROI* process variables to initialize the peak and background ranges
         self.process_pv_roi(ws)
-        # Is User overriding the any of the ROI regions?
+        # Is User overriding any of the ROI regions?
         if self.force_peak_roi:
             logger.notice("Forcing peak ROI: %s" % self.forced_peak_roi)
             self.roi_peak = self.forced_peak_roi

--- a/src/mr_reduction/inspect_data.py
+++ b/src/mr_reduction/inspect_data.py
@@ -373,11 +373,17 @@ class DataInspector(object):
                 else:
                     background_roi_xmax = run["ROI2EndX"].getStatistics().mean
 
-                # Along the X-axis, the beginning of the background occurs before the beginning of the peak
-                if background_roi_xmin >= peak_roi_xmin:
-                    logger.warning("Process variable ROI2StartX is bigger than ROI1StartX")
-                elif background_roi_xmax > background_roi_xmin:
+                # case 1: Along the X-axis, the background occurs at lower values than the peak
+                case1 = background_roi_xmax < peak_roi_xmin
+                # case 2: Along the X-axis, the peak region is inside the background region
+                case2 = background_roi_xmin < peak_roi_xmin and background_roi_xmax > peak_roi_xmax
+                if case1 or case2:
                     background_roi_x = [int(background_roi_xmin), int(background_roi_xmax)]
+                else:
+                    logger.warning(
+                        "Background region is not before the peak region "
+                        "or the peak region is not inside the background region!"
+                    )
 
         # Update the ROI attributes
         self.roi_peak = peak_roi_x

--- a/tests/integration/test_mr_reduction.py
+++ b/tests/integration/test_mr_reduction.py
@@ -99,7 +99,7 @@ class TestReduction:
                 usecols=1,
                 comments="#",
             )
-            assert np.all((reflectivities[:20] >= 0.08) & (reflectivities[:20] <= 0.1))
+            assert np.all((reflectivities[:18] >= 0.09) & (reflectivities[:18] <= 0.11))
 
     @pytest.mark.datarepo()
     def test_reduce_many_cross_sections_2(self, mock_filesystem, data_server):

--- a/tests/integration/test_mr_reduction.py
+++ b/tests/integration/test_mr_reduction.py
@@ -42,8 +42,8 @@ class TestReduction:
             assert os.path.isfile(os.path.join(mock_filesystem.tempdir, file))
         questor = io_orso.Questor(filepath=os.path.join(mock_filesystem.tempdir, "REF_M_29160_2_combined.ort"))
         questor.assert_equal(cross_sections=["Off_Off"], polarizations=["pp"])
-        # compare the first two elements of column R of the first dataset to [0.00342, 0.00349]
-        questor.assert_almost_equal(decimal=4, partial_match=True, column_R=[[0.0187, 0.0198]])
+        # compare the first two elements of column R of the first dataset to [0.0164, 0.01745]
+        questor.assert_almost_equal(decimal=4, partial_match=True, column_R=[[0.0164, 0.01745]])
 
     @pytest.mark.datarepo()
     def test_reduce_many_cross_sections_1(self, data_server, mock_filesystem):

--- a/tests/unit/mr_reduction/test_inspect_data.py
+++ b/tests/unit/mr_reduction/test_inspect_data.py
@@ -1,0 +1,86 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from mr_reduction.inspect_data import DataInspector
+
+
+class TestDataInspector:
+    @patch("mr_reduction.inspect_data.workspace_handle")
+    @pytest.mark.parametrize(
+        "startx, sizex, starty, sizey, roi2_startx, roi2_sizex, peak, low_res, background",  # noqa PT006
+        [
+            # Case 1: ROI1 [100, 150] inside ROI2 [90, 160]
+            (100, 50, 10, 90, 90, 70, [100, 150], [10, 100], [90, 160]),
+            # Case 2: ROI2 [10, 20] occurs at lower values than ROI1 [100, 150]
+            (100, 50, 10, 90, 10, 10, [100, 150], [10, 100], [10, 20]),
+            # invalid: ROI2 [200, 220] occurs at higher values than ROI1 [100, 150]
+            (100, 50, 10, 90, 200, 20, [100, 150], [10, 100], [0, 0]),
+            # invalid: ROI2 [110, 130] inside ROI1 [100, 150]
+            (100, 50, 10, 90, 110, 20, [100, 150], [10, 100], [0, 0]),
+            # invalid: ROI2 [110, 210] starts inside ROI1 [100, 150]
+            (100, 50, 10, 90, 110, 100, [100, 150], [10, 100], [0, 0]),
+            # invalide: ROI2 [90, 110] ends inside ROI1 [100, 150]
+            (100, 50, 10, 90, 90, 20, [100, 150], [10, 100], [0, 0]),
+        ],
+    )
+    def test_process_pv_roi(
+        self,
+        mock_workspace_handle,
+        startx,
+        sizex,
+        starty,
+        sizey,
+        roi2_startx,
+        roi2_sizex,
+        peak,
+        low_res,
+        background,
+    ):
+        """
+        Test scenarios for DataInspector's `process_pv_roi` method.
+
+        The test cases focus on validating a variety of Region of Interest (ROI) configurations
+        and how the `process_pv_roi` method interprets and processes them. Mock
+        objects and parameterized data are used to simulate input workspaces and
+        expected results.
+        """
+
+        class MockDataInspector(DataInspector):
+            # a simplified __init__ prevents all the work that DataInspector.__init__ does
+            def __init__(self, input_workspace):  # noqa: ARG002
+                self.roi_peak = None
+                self.roi_low_res = None
+                self.roi_background = None
+
+        # Mock EventWorkspace and its getRun method. Mock function workspace_handle
+        mock_workspace = MagicMock()
+        mock_workspace_handle.return_value = mock_workspace
+        mock_run = {
+            "ROI1StartX": MagicMock(),
+            "ROI1SizeX": MagicMock(),
+            "ROI1StartY": MagicMock(),
+            "ROI1SizeY": MagicMock(),
+            "ROI2StartX": MagicMock(),
+            "ROI2SizeX": MagicMock(),
+        }
+        # Set mock values
+        mock_run["ROI1StartX"].getStatistics().mean = startx
+        mock_run["ROI1SizeX"].getStatistics().mean = sizex
+        mock_run["ROI1StartY"].getStatistics().mean = starty
+        mock_run["ROI1SizeY"].getStatistics().mean = sizey
+        mock_run["ROI2StartX"].getStatistics().mean = roi2_startx
+        mock_run["ROI2SizeX"].getStatistics().mean = roi2_sizex
+        mock_workspace.getRun.return_value = mock_run
+
+        # Create a MockDataInspector instance and call process_pv_roi
+        inspector = MockDataInspector(input_workspace=mock_workspace)
+        inspector.process_pv_roi(mock_workspace)
+
+        # Assert the calculated ROIs
+        assert inspector.roi_peak == peak
+        assert inspector.roi_low_res == low_res
+        assert inspector.roi_background == background
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
## Description of work:
Simplified logic for `process_roi`, also caught a bug that set the background ROI along the X-axis to [0, 0] when the background occurred at lower values of X than the peak. This should not happen.

Check all that apply:
- [x] added [release notes](https://mr-reduction.readthedocs.io/en/latest/releases.html)
(if not, provide an explanation in the work description)
- [ ] ~Documentation updated~
- [x] Source added/refactored
- [ ] ~Unit tests added/refactored~
- [ ] ~Integration tests added/refactored~

**References:**
- Links to IBM EWM items:[11171](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=11171)

## :warning: Manual test for the reviewer
Nothing to test manually 

## Check list for the reviewer
- [ ] [release notes](https://mr-reduction.readthedocs.io/en/latest/releases.html)
updated, or an explanation is provided as to why release notes are unnecessary
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
