### PR TITLE
Rearranged how X-TOF plot was being displayed

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -12,7 +12,7 @@ Notes for major and minor releases. Notes for patch releases are referred to the
 
    **Of interest to the User:**
 
-   - PR #
+   - PR #66 X-TOF plot now shows up second and axes are flipped
 
    **Of interest to the Developer:**
 
@@ -25,7 +25,7 @@ v2.5.0
 
 **Of interest to the User:**
 
-- PR #66 X-TOF plot now shows up second and axes are flipped
+- PR #
 
 **Of interest to the Developer:**
 

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -25,7 +25,7 @@ v2.5.0
 
 **Of interest to the User:**
 
-- PR #
+- PR #66 X-TOF plot now shows up second and axes are flipped
 
 **Of interest to the Developer:**
 

--- a/src/mr_reduction/web_report.py
+++ b/src/mr_reduction/web_report.py
@@ -470,13 +470,13 @@ class Report:
             if self.plot_2d:
                 x_tof_plot = _plot2d(
                     z=signal,
-                    y=tof_axis,
-                    x=list(range(signal.shape[0])),
-                    x_range=scatt_peak,
-                    x_bck_range=self.data_info.background,
-                    y_range=None,
-                    x_label="X pixel",
-                    y_label="TOF (ms)",
+                    y=list(range(signal.shape[0])),
+                    x=tof_axis,
+                    x_range=None,
+                    y_range=scatt_peak,
+                    y_bck_range=self.data_info.background,
+                    x_label="TOF (ms)",
+                    y_label="X pixel",
                     title="r%s [%s]" % (self.data_info.run_number, cross_section),
                 )
         except:  # noqa E722
@@ -548,7 +548,7 @@ class Report:
         except:  # noqa E722
             self.log("  - Could not generate TOF distribution")
 
-        return [xy_plot, peak_pixels, low_res_profile, x_tof_plot, tof_dist]
+        return [xy_plot, x_tof_plot, peak_pixels, low_res_profile, tof_dist]
 
 
 def _plot2d(
@@ -588,6 +588,12 @@ def _plot2d(
     x_flat, y_flat, z_flat = x_grid.flatten(), y_grid.flatten(), z.flatten()
     threshold = 0.01 * np.max(z_flat)
     mask = np.isfinite(z_flat) & (z_flat > threshold)  # Keep only significant values (exclude NaN, -inf, inf)
+
+    # This is a temporary fix
+    if len(z_flat) != len(x_flat):
+        z_flat = np.resize(z_flat, (len(x_flat)))
+        mask = np.resize(mask, (len(x_flat)))
+
     x_sparse, y_sparse, z_sparse = x_flat[mask], y_flat[mask], z_flat[mask]
 
     # Round the remaining values to a certain number of decimal places, for instance 0.003455245 to 0.0034.


### PR DESCRIPTION
## Description of work:
Changed X-TOF plot to be second plot to be displayed. Also swapped axis.

Check all that apply:
- [x] added [release notes](https://mr-reduction.readthedocs.io/en/latest/releases.html)
(if not, provide an explanation in the work description)
- [ ] Documentation updated
- [x] Source added/refactored
- [ ] Unit tests added/refactored
- [ ] Integration tests added/refactored

**References:**
- Links to IBM EWM items: [11291](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=11291)
- Links to related issues or pull requests:

## :warning: Manual test for the reviewer
Run src/mr_autoreduce/reduce_REF_M_run.sh and go to the web page. Assuming you have access to the run, you should just be able to click submit and then view the report when it is done. Make sure the X-TOF is in the right position and that the axes are now flipped.

## Check list for the reviewer
- [ ] [release notes](https://mr-reduction.readthedocs.io/en/latest/releases.html)
updated, or an explanation is provided as to why release notes are unnecessary
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
