### PR TITLE
Raise Exception for Insufficient Events File

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -12,6 +12,7 @@ Notes for major and minor releases. Notes for patch releases are referred to the
 
    **Of interest to the User:**
 
+   - PR #68 An informative exception is now raised when a file with an insufficient number of events is attempted to be reduced
    - PR #66 X-TOF plot now shows up second and axes are flipped
 
    **Of interest to the Developer:**

--- a/src/mr_reduction/mr_reduction.py
+++ b/src/mr_reduction/mr_reduction.py
@@ -303,7 +303,7 @@ class ReductionProcess:
 
         if self.data_ws.getNumberEvents() < REFLECTED_BEAM_EVTS_MIN:
             raise ValueError(
-                f"Insufficent Number of Reflected Beam Events: {self.data_ws.getNumberEvents()} "
+                f"Insufficent number of reflected beam events: {self.data_ws.getNumberEvents()} "
                 f"(Minimum of {REFLECTED_BEAM_EVTS_MIN} events required)"
             )
 

--- a/src/mr_reduction/mr_reduction.py
+++ b/src/mr_reduction/mr_reduction.py
@@ -41,6 +41,7 @@ from mr_reduction.types import MantidWorkspace, WorkspaceGroup
 from mr_reduction.web_report import Report, process_collection
 
 DIRECT_BEAM_EVTS_MIN = 1000
+REFLECTED_BEAM_EVTS_MIN = 200
 
 
 class ReductionProcess:
@@ -50,7 +51,7 @@ class ReductionProcess:
 
     tolerance = 0.02
     # Minimum number of events needed to go ahead with the reduction
-    min_number_events = 200
+    min_number_events = REFLECTED_BEAM_EVTS_MIN
     pol_state = POL_STATE
     pol_veto = POL_VETO
     ana_state = ANA_STATE
@@ -299,6 +300,13 @@ class ReductionProcess:
         # if self.data_ws is not None and self.use_slow_flipper_log:
         if self.data_ws is None:
             self.data_ws = LoadEventNexus(Filename=self.file_path, OutputWorkspace="raw_events")
+
+        if self.data_ws.getNumberEvents() < REFLECTED_BEAM_EVTS_MIN:
+            raise ValueError(
+                f"Insufficent Number of Reflected Beam Events: {self.data_ws.getNumberEvents()} "
+                f"(Minimum of {REFLECTED_BEAM_EVTS_MIN} events required)"
+            )
+
         self.run_number = int(self.data_ws.getRunNumber())
 
         if self.use_slow_flipper_log:

--- a/src/mr_reduction/mr_reduction.py
+++ b/src/mr_reduction/mr_reduction.py
@@ -301,10 +301,10 @@ class ReductionProcess:
         if self.data_ws is None:
             self.data_ws = LoadEventNexus(Filename=self.file_path, OutputWorkspace="raw_events")
 
-        if self.data_ws.getNumberEvents() < REFLECTED_BEAM_EVTS_MIN:
+        if self.data_ws.getNumberEvents() < self.min_number_events:
             raise ValueError(
-                f"Insufficent number of reflected beam events: {self.data_ws.getNumberEvents()} "
-                f"(Minimum of {REFLECTED_BEAM_EVTS_MIN} events required)"
+                f"Insufficient number of reflected beam events: {self.data_ws.getNumberEvents()} "
+                f"(Minimum of {self.min_number_events} events required)"
             )
 
         self.run_number = int(self.data_ws.getRunNumber())

--- a/tests/integration/test_mr_reduction.py
+++ b/tests/integration/test_mr_reduction.py
@@ -243,12 +243,8 @@ class TestReduction:
         )
 
         # call the process and catch the expected exception
-        with pytest.raises(ValueError, match="Insufficent number of reflected beam events") as e:
+        with pytest.raises(ValueError, match="Insufficient number of reflected beam events"):
             processor.reduce()
-
-        # some sanity checks
-        assert e.type is ValueError
-        assert str(e.value).startswith("Insufficent number of reflected beam events")
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_mr_reduction.py
+++ b/tests/integration/test_mr_reduction.py
@@ -8,6 +8,9 @@ import numpy as np
 # third party imports
 import pytest
 
+# mantid imports
+from mantid.simpleapi import AddSampleLog, CreateSampleWorkspace
+
 # mr_reduction imports
 import mr_reduction.mr_reduction as mr
 from mr_reduction import io_orso
@@ -221,6 +224,31 @@ class TestReduction:
             # inquire the combined ORSO files
             questor = io_orso.Questor(filepath=os.path.join(mock_filesystem.tempdir, f"REF_M_42535_{sn}_combined.ort"))
             questor.assert_equal(cross_sections=["Off_Off", "On_Off"], polarizations=["po", "mo"])
+
+    def test_reduce_ValueError_insufficient_event_count(self):
+        r"""Test that the minumum number of events is enforced"""
+
+        # create an empty events workspace
+        ws = CreateSampleWorkspace(WorkspaceType="Event", NumEvents=0)
+
+        # add some mr_red required sample logs
+        AddSampleLog(ws, "Polarizer", LogText="0", LogType="Number")
+        AddSampleLog(ws, "Analyzer", LogText="0", LogType="Number")
+
+        # instantiate the process
+        processor = mr.ReductionProcess(
+            data_run="44470",  # run that motivated this test
+            data_ws=ws,
+            publish=False,  # don't upload to the livedata server
+        )
+
+        # call the process and catch the expected exception
+        with pytest.raises(ValueError, match="Insufficent Number of Reflected Beam Events") as e:
+            processor.reduce()
+
+        # some sanity checks
+        assert e.type is ValueError
+        assert str(e.value).startswith("Insufficent Number of Reflected Beam Events")
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_mr_reduction.py
+++ b/tests/integration/test_mr_reduction.py
@@ -226,7 +226,7 @@ class TestReduction:
             questor.assert_equal(cross_sections=["Off_Off", "On_Off"], polarizations=["po", "mo"])
 
     def test_reduce_ValueError_insufficient_event_count(self):
-        r"""Test that the minumum number of events is enforced"""
+        r"""Test that the minimum number of events is enforced"""
 
         # create an empty events workspace
         ws = CreateSampleWorkspace(WorkspaceType="Event", NumEvents=0)
@@ -243,12 +243,12 @@ class TestReduction:
         )
 
         # call the process and catch the expected exception
-        with pytest.raises(ValueError, match="Insufficent Number of Reflected Beam Events") as e:
+        with pytest.raises(ValueError, match="Insufficent number of reflected beam events") as e:
             processor.reduce()
 
         # some sanity checks
         assert e.type is ValueError
-        assert str(e.value).startswith("Insufficent Number of Reflected Beam Events")
+        assert str(e.value).startswith("Insufficent number of reflected beam events")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description of work:
[Autoreduction of run 44470 failed with reported error message REDUCTION: list index out of range](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemOid/com.ibm.team.workitem.Attachment/_BGpycCwxEfCe5ff0IhlkFg) .
This error is very misleading. Loading file /SNS/REF_M/IPTS-32909/nexus/REF_M_44470.nxs.h5 in [Mantid shows the file has zero events](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemOid/com.ibm.team.workitem.Attachment/_CN8KoCwxEfCe5ff0IhlkFg) .
Thus, mr_reduction should check for number of events below certain threshold (something similar to [DIRECT_BEAM_EVTS_MIN](https://github.com/neutrons/MagnetismReflectometer/blob/37bbcfae9da3948523107db5da46b4bf685bbdbb/src/mr_reduction/mr_reduction.py#L43) ) after the file is loaded, and raise an informative exception.

This work adds such a check and raises an informative exception if there are insufficient events.
A test is added for this feature.

Check all that apply:
- [X] added [release notes](https://mr-reduction.readthedocs.io/en/latest/releases.html)
(if not, provide an explanation in the work description)
- [ ] Documentation updated
- [X] Source added/refactored
- [ ] Unit tests added/refactored
- [X] Integration tests added/refactored

**References:**
- Links to IBM EWM items: [11195: [MrRED] Raise informative exception after loading an emtpy events file](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/11195)
- Links to related issues or pull requests:

## :warning: Manual test for the reviewer
(Instructions for testing here)

## Check list for the reviewer
- [ ] [release notes](https://mr-reduction.readthedocs.io/en/latest/releases.html)
updated, or an explanation is provided as to why release notes are unnecessary
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
