### PR TITLE
Replaced use of mantidworkbench with just mantid

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -37,7 +37,7 @@ requirements:
 
   run:
     - python
-    - mantidworkbench>=6.12.0.2
+    - mantid>=6.12.0.2
     - numpy
     - scipy
     - pandas

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -27,6 +27,10 @@ v2.7.0
 
 - PR #68 Informative exception raised when a file with an insufficient number of events is attempted to be reduced
 
+**Of interest to the Developer:**
+
+- PR #70 use of mantidworkbench conda package is replaced with mantid
+
 
 v2.6.0
 ------

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -16,7 +16,7 @@ Notes for major and minor releases. Notes for patch releases are referred to the
 
    **Of interest to the Developer:**
 
-   - PR #
+   - PR #70 use of mantidworkbench conda package is replaced with mantid
 ..
 
 v2.7.0
@@ -26,11 +26,6 @@ v2.7.0
 **Of interest to the User:**
 
 - PR #68 Informative exception raised when a file with an insufficient number of events is attempted to be reduced
-
-**Of interest to the Developer:**
-
-- PR #70 use of mantidworkbench conda package is replaced with mantid
-
 
 v2.6.0
 ------

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - argcomplete
   - flask
   - gunicorn
-  - mantidworkbench>=6.12.0.2
+  - mantid>=6.12.0.2
   - neutrons::finddata=0.10
   - pandas
   - pip


### PR DESCRIPTION
## Description of work:
Updated conda environment to use mantid instead of mantidworkbench.

Check all that apply:
- [ ] added [release notes](https://mr-reduction.readthedocs.io/en/latest/releases.html)
(if not, provide an explanation in the work description)
- [ ] Documentation updated
- [ ] Source added/refactored
- [ ] Unit tests added/refactored
- [ ] Integration tests added/refactored

**References:**
- Links to IBM EWM items: [11431](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=11431)
- Links to related issues or pull requests:

## :warning: Manual test for the reviewer
Just make sure MrRED still functions as normal

## Check list for the reviewer
- [ ] [release notes](https://mr-reduction.readthedocs.io/en/latest/releases.html)
updated, or an explanation is provided as to why release notes are unnecessary
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
