### PR TITLE
Do not use "pixi run" when testing the conda package

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -84,8 +84,9 @@ jobs:
           package-name: ${{ env.PKG_NAME }}
           extra-channels: mantid neutrons oncat
           extra-commands: |
-            pixi run python -c "import mantid"
-            pixi run python -c "import pyoncat"
+            which python
+            python -c "import mantid"
+            python -c "import pyoncat"
 
       # Upload the conda package for job "publish" to use later
       - name: upload conda package as artifact


### PR DESCRIPTION
## Description of work:
This PR updates the test_and_deploy.yml workflow to simplify Python import commands by removing the pixi run prefix and adding a debug command to check the Python executable location.

Replaces pixi run python with direct python commands for import tests
Adds which python command to verify Python executable location

Check all that apply:
- [ ] ~Documentation updated~
- [x] Source added/refactored~
- [ ] ~Unit tests added/refactored~
- [ ] ~Integration tests added/refactored~

**References:**
- ~Links to IBM EWM items~


## Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
