### PR TITLE
Fix generated Python scripts

### DIFF
--- a/tests/integration/test_script_output.py
+++ b/tests/integration/test_script_output.py
@@ -1,0 +1,65 @@
+import pytest
+from mantid.simpleapi import LoadEventNexus, mtd
+from numpy.testing import assert_allclose
+
+from mr_reduction.mr_reduction import ReductionProcess
+from mr_reduction.runpeak import RunPeakNumber
+from mr_reduction.script_output import generate_script_from_ws
+
+
+@pytest.mark.datarepo
+def test_generate_script_from_ws(data_server, tmp_path, mock_filesystem):
+    """Test generation of reduction script from reflectivity workspace.
+
+    Steps taken in this test:
+    1. Reduces a data run.
+    2. Generates a script from the resulting reflectivity workspace.
+    3. Executes the generated script.
+    4. Verifies that the reflectivity data matches.
+
+    Note that the reflectivity data does not match exactly. One source of
+    discrepancy is that the reduction parameters are written with limited
+    precision in the generated Python script.
+    """
+    # Load data run
+    workspace = LoadEventNexus(Filename=data_server.path_to("REF_M_44382.nxs.h5"), OutputWorkspace="ws_44382")
+    peak_number = 1
+
+    # Reduce data run
+    output_dir = tmp_path / "output"
+    mock_filesystem.DirectBeamFinder.return_value.search.return_value = 44380
+    ReductionProcess(data_run="44382", data_ws=workspace, output_dir=output_dir, peak_number=peak_number).reduce()
+
+    # Generate Python script from reflectivity workspace
+    runpeak = RunPeakNumber("44382", peak_number)
+    ws_refl_xs = mtd[f"r_{runpeak}"][0]
+    x_expected, y_expected, dy_expected, dx_expected = (
+        ws_refl_xs.readX(0),
+        ws_refl_xs.readY(0),
+        ws_refl_xs.readE(0),
+        ws_refl_xs.readDx(0),
+    )
+
+    script = generate_script_from_ws(
+        [ws_refl_xs], group_name=str(ws_refl_xs), quicknxs_mode=False, include_workspace_string=False
+    )
+
+    # Execute the generated script to be able to compare results
+    globals_ = {}
+    exec(script, globals_)
+
+    # The reflectivity workspace has been replaced in MDS
+    ws_refl = mtd[f"r_{runpeak}"]
+    ws_refl_xs = ws_refl[0]
+    x_actual, y_actual, dy_actual, dx_actual = (
+        ws_refl_xs.readX(0),
+        ws_refl_xs.readY(0),
+        ws_refl_xs.readE(0),
+        ws_refl_xs.readDx(0),
+    )
+
+    # Verify that the reflectivity data matches
+    assert_allclose(x_expected, x_actual, rtol=1e-5)
+    assert_allclose(y_expected, y_actual, rtol=0.01)
+    assert_allclose(dy_expected, dy_actual, rtol=0.01)
+    assert_allclose(dx_expected, dx_actual, rtol=1e-5)

--- a/tests/integration/test_script_output.py
+++ b/tests/integration/test_script_output.py
@@ -63,3 +63,33 @@ def test_generate_script_from_ws(data_server, tmp_path, mock_filesystem):
     assert_allclose(y_expected, y_actual, rtol=0.01)
     assert_allclose(dy_expected, dy_actual, rtol=0.01)
     assert_allclose(dx_expected, dx_actual, rtol=1e-5)
+
+
+@pytest.mark.datarepo
+def test_write_reduction_script(data_server):
+    """Test that the combined reduction script runs without errors.
+
+    Note: This test runs the gold combined script, however, the content of the
+    generated combined script is verified separately in
+    tests/unit/mr_reduction/test_script_output.py.
+    """
+    with open(data_server.path_to("REF_M_42535_1_combined.py")) as fd:
+        # replace <FILE_PATH> with actual path
+        script = fd.read()
+        script = script.replace("<FILE_PATH>", data_server.datarepo)
+
+    # Execute the reduction script
+    globals_ = {}
+    exec(script, globals_)
+
+    # Verify that the reflectivity workspaces were created
+    reflectivity_workspaces = [
+        "42535_Off_Off__reflectivity",
+        "42536_Off_Off__reflectivity",
+        "42537_Off_Off__reflectivity",
+        "42535_On_Off__reflectivity",
+        "42536_On_Off__reflectivity",
+        "42537_On_Off__reflectivity",
+    ]
+    for ws_name in reflectivity_workspaces:
+        assert ws_name in mtd

--- a/tests/unit/mr_reduction/test_script_output.py
+++ b/tests/unit/mr_reduction/test_script_output.py
@@ -1,5 +1,5 @@
-import os
 import re
+import shutil
 from pathlib import Path
 
 import pytest
@@ -7,7 +7,7 @@ from mantid.simpleapi import LoadEventNexus, mtd
 
 from mr_reduction.mr_reduction import ReductionProcess
 from mr_reduction.runpeak import RunPeakNumber
-from mr_reduction.script_output import generate_script_from_ws
+from mr_reduction.script_output import generate_script_from_ws, write_reduction_script
 
 
 def _normalize_paths(text: str, placeholder: str = "<FILE_PATH>") -> str:
@@ -25,20 +25,26 @@ def _normalize_paths(text: str, placeholder: str = "<FILE_PATH>") -> str:
     )
 
 
+def _remove_comments(text: str) -> str:
+    """Remove comments from the script text for comparison purposes."""
+    return re.sub(r"#.*", "", text)
+
+
 @pytest.mark.datarepo
 def test_generate_script_from_ws(data_server, tmp_path, mock_filesystem):
     """Test generation of reduction script from workspace group."""
     # Load data run
     workspace = LoadEventNexus(Filename=data_server.path_to("REF_M_44382.nxs.h5"), OutputWorkspace="ws_44382")
+    peak_number = 1
 
     # Reduce data run
     output_dir = tmp_path / "output"
     mock_filesystem.DirectBeamFinder.return_value.search.return_value = 44380
-    ReductionProcess(data_run="44382", data_ws=workspace, output_dir=output_dir).reduce()
+    ReductionProcess(data_run="44382", data_ws=workspace, output_dir=output_dir, peak_number=peak_number).reduce()
 
     # Generate script from reflectivity workspace
-    runpeak = RunPeakNumber("44382", None)
-    ws_refl = mtd["r_%s" % runpeak]
+    runpeak = RunPeakNumber("44382", peak_number)
+    ws_refl = mtd[f"r_{runpeak}"]
     script = generate_script_from_ws(ws_refl, group_name=str(ws_refl))
 
     generated = _normalize_paths(script)
@@ -49,3 +55,30 @@ def test_generate_script_from_ws(data_server, tmp_path, mock_filesystem):
 
     # Verify script content
     assert generated == expected
+
+
+@pytest.mark.datarepo
+def test_write_reduction_script(data_server, tmp_path):
+    """Test writing of combined reduction script."""
+    # Copy partial scripts to temporary autoreduce directory
+    ar_dir = tmp_path / "autoreduce"
+    ar_dir.mkdir(parents=True, exist_ok=True)
+    runpeaks = [RunPeakNumber("42535", 1), RunPeakNumber("42536", 1), RunPeakNumber("42537", 1)]
+    for runpeak in runpeaks:
+        partial_file_path = data_server.path_to(f"REF_M_{runpeak}_partial.py")
+        shutil.copy(partial_file_path, ar_dir)
+
+    # Write combined script from partial scripts
+    scaling_factors = [1.0, 0.95, 0.8]
+    script_filepath = write_reduction_script(runpeaks, scaling_factors, str(ar_dir))
+
+    with open(script_filepath) as fd:
+        actual = _normalize_paths(fd.read())
+        actual = _remove_comments(actual)
+
+    with open(data_server.path_to("REF_M_42535_1_combined.py")) as fd:
+        expected = _normalize_paths(fd.read())
+        expected = _remove_comments(expected)
+
+    # Verify script content
+    assert actual == expected

--- a/tests/unit/mr_reduction/test_script_output.py
+++ b/tests/unit/mr_reduction/test_script_output.py
@@ -1,0 +1,51 @@
+import os
+import re
+from pathlib import Path
+
+import pytest
+from mantid.simpleapi import LoadEventNexus, mtd
+
+from mr_reduction.mr_reduction import ReductionProcess
+from mr_reduction.runpeak import RunPeakNumber
+from mr_reduction.script_output import generate_script_from_ws
+
+
+def _normalize_paths(text: str, placeholder: str = "<FILE_PATH>") -> str:
+    """Replace file paths with a placeholder for comparison purposes."""
+
+    def repl(match: re.Match) -> str:
+        path = match.group("path")
+        filename = Path(path).name
+        return f"Filename='{placeholder}/{filename}'"
+
+    return re.sub(
+        r"Filename\s*=\s*'(?P<path>[^']+)'",
+        repl,
+        text,
+    )
+
+
+@pytest.mark.datarepo
+def test_generate_script_from_ws(data_server, tmp_path, mock_filesystem):
+    """Test generation of reduction script from workspace group."""
+    # Load data run
+    workspace = LoadEventNexus(Filename=data_server.path_to("REF_M_44382.nxs.h5"), OutputWorkspace="ws_44382")
+
+    # Reduce data run
+    output_dir = tmp_path / "output"
+    mock_filesystem.DirectBeamFinder.return_value.search.return_value = 44380
+    ReductionProcess(data_run="44382", data_ws=workspace, output_dir=output_dir).reduce()
+
+    # Generate script from reflectivity workspace
+    runpeak = RunPeakNumber("44382", None)
+    ws_refl = mtd["r_%s" % runpeak]
+    script = generate_script_from_ws(ws_refl, group_name=str(ws_refl))
+
+    generated = _normalize_paths(script)
+
+    with open(data_server.path_to(f"REF_M_{runpeak}_partial.py")) as fd:
+        expected_text = fd.read()
+        expected = _normalize_paths(expected_text)
+
+    # Verify script content
+    assert generated == expected


### PR DESCRIPTION
## Description of work:

Due to some changes in the reduction workflow, the Mantid algorithm `GeneratePythonScript` no longer generated complete Python scripts from the reflectivity workspace. This PR modifies the function generating the script to insert needed functions that are not part of the workspace history. The scripts now have to be run in an environment with access to `mr_reduction` functions.

The PR adds test verifying:
- that the generated script matches the gold generated script
- that the output reflectivity from the generated script matches the output reflectivity from the reduction workflow

Check all that apply:
- [ ] ~~Documentation updated~~
- [x] Source added/refactored
- [x] Unit tests added/refactored
- [x] Integration tests added/refactored

**References:**
- Links to IBM EWM items: [Defect 14739: [mr_reduction] Python scripts generated during autoreduction are missing cross section filtering](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=14739&tab=com.ibm.team.workitem.tab.links)
- Links to related issues or pull requests:

## :warning: Manual test for the reviewer
(Instructions for testing here)

On this branch on the analysis cluster:

```
pixi shell
cp /SNS/REF_M/shared/autoreduce/reduce_REF_M.py .
mkdir output
python reduce_REF_M.py /SNS/REF_M/IPTS-31954/nexus/REF_M_42535.nxs.h5 ./output --no_publish
# run the generated combined script (built from the partial scripts) to see that it runs without errors
python output/REF_M_42535_1_combined.py
```

## Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
