### PR TITLE
Add polarization log setup to the generated python scripts

### DIFF
--- a/src/mr_reduction/filter_events.py
+++ b/src/mr_reduction/filter_events.py
@@ -131,10 +131,10 @@ def create_table(
 def filter_cross_sections(
     events_workspace: EventWorkspace,
     output_workspace: str,
-    pv_polarizer_state: str = PolarizationLogs.POL_STATE,
-    pv_analyzer_state: str = PolarizationLogs.ANA_STATE,
-    pv_polarizer_veto: str = PolarizationLogs.POL_VETO,
-    pv_analyzer_veto: str = PolarizationLogs.ANA_VETO,
+    pv_polarizer_state: str = PolarizationLogs().pol_state,
+    pv_analyzer_state: str = PolarizationLogs().ana_state,
+    pv_polarizer_veto: str = PolarizationLogs().pol_veto,
+    pv_analyzer_veto: str = PolarizationLogs().ana_veto,
     check_devices: bool = True,
 ) -> WorkspaceGroup:
     """
@@ -498,10 +498,10 @@ def split_events(
         xs_list = filter_cross_sections(
             events_workspace,
             output_workspace,
-            pv_polarizer_state=polarization_logs.POL_STATE,
-            pv_analyzer_state=polarization_logs.ANA_STATE,
-            pv_polarizer_veto=polarization_logs.POL_VETO,
-            pv_analyzer_veto=polarization_logs.ANA_VETO,
+            pv_polarizer_state=polarization_logs.pol_state,
+            pv_analyzer_state=polarization_logs.ana_state,
+            pv_polarizer_veto=polarization_logs.pol_veto,
+            pv_analyzer_veto=polarization_logs.ana_veto,
             check_devices=check_devices,
         )
 
@@ -566,13 +566,13 @@ def split_error_events(
     if use_slow_flipper_log:
         err_ws_list = slow_filter_cross_sections(err_ws, prefix=f"{output_workspace}_err")
     else:
-        pol_veto = polarization_logs.POL_VETO if polarization_logs.POL_VETO in metadata else ""
-        ana_veto = polarization_logs.ANA_VETO if polarization_logs.ANA_VETO in metadata else ""
+        pol_veto = polarization_logs.pol_veto if polarization_logs.pol_veto in metadata else ""
+        ana_veto = polarization_logs.ana_veto if polarization_logs.ana_veto in metadata else ""
         err_ws_list = filter_cross_sections(
             err_ws,
             output_workspace=f"{output_workspace}_err",
-            pv_polarizer_state=polarization_logs.POL_STATE,
-            pv_analyzer_state=polarization_logs.ANA_STATE,
+            pv_polarizer_state=polarization_logs.pol_state,
+            pv_analyzer_state=polarization_logs.ana_state,
             pv_polarizer_veto=pol_veto,
             pv_analyzer_veto=ana_veto,
         )

--- a/src/mr_reduction/mr_reduction.py
+++ b/src/mr_reduction/mr_reduction.py
@@ -367,7 +367,7 @@ class ReductionProcess:
 
         # Generate partial python script
         self.log("Workspace r_%s: %s" % (runpeak, type(mtd["r_%s" % runpeak])))
-        write_partial_script(mtd["r_%s" % runpeak], self.output_dir)
+        write_partial_script(mtd["r_%s" % runpeak], self.output_dir, polarization_logs=self.polarization_logs)
 
         report_list = []
         reflectivity_workspaces: List[MantidWorkspace] = []

--- a/src/mr_reduction/script_output.py
+++ b/src/mr_reduction/script_output.py
@@ -234,9 +234,14 @@ ws_list = split_events(input_workspace=ws, polarization_logs=polarization_logs)"
     _insert_relative_to_keyword(lines, "ws = LoadEventNexus", split_events_snippet, mode=StringInsertMode.AFTER)
 
     # reformat for better readability
-    refl_algo_idx = [i for i, line in enumerate(lines) if "MagnetismReflectometryReduction(" in line]
-    tmp_refl_algo_line = lines[refl_algo_idx[0]].replace(", ", ",\n                                ")
-    lines[refl_algo_idx[0]] = tmp_refl_algo_line
+    refl_algo_idx = next((i for i, line in enumerate(lines) if "MagnetismReflectometryReduction(" in line), None)
+    if refl_algo_idx is None:
+        api.logger.warning(
+            "Failed to reformat generated script around 'MagnetismReflectometryReduction('. Pattern not found."
+        )
+    else:
+        tmp_refl_algo_line = lines[refl_algo_idx].replace(", ", ",\n                                ")
+        lines[refl_algo_idx] = tmp_refl_algo_line
     script_text = "\n".join(lines)
     script += script_text
     script += "\n"

--- a/src/mr_reduction/script_output.py
+++ b/src/mr_reduction/script_output.py
@@ -225,10 +225,10 @@ def generate_script_from_ws(
 from mr_reduction.settings import PolarizationLogs"""
     _insert_relative_to_keyword(lines, "from mantid.simpleapi import *", imports_snippet, mode=StringInsertMode.AFTER)
     _insert_relative_to_keyword(lines, "LoadEventNexus", "ws = ", mode=StringInsertMode.PREPEND)
-    polarization_logs_snippet = f'polarization_logs = PolarizationLogs(pol_state="{polarization_logs.POL_STATE}", '
-    polarization_logs_snippet += f'pol_veto="{polarization_logs.POL_VETO}", '
-    polarization_logs_snippet += f'ana_state="{polarization_logs.ANA_STATE}", '
-    polarization_logs_snippet += f'ana_veto="{polarization_logs.ANA_VETO}")'
+    polarization_logs_snippet = f'polarization_logs = PolarizationLogs(pol_state="{polarization_logs.pol_state}", '
+    polarization_logs_snippet += f'pol_veto="{polarization_logs.pol_veto}", '
+    polarization_logs_snippet += f'ana_state="{polarization_logs.ana_state}", '
+    polarization_logs_snippet += f'ana_veto="{polarization_logs.ana_veto}")'
     split_events_snippet = f"""{polarization_logs_snippet}
 ws_list = split_events(input_workspace=ws, polarization_logs=polarization_logs)"""
     _insert_relative_to_keyword(lines, "ws = LoadEventNexus", split_events_snippet, mode=StringInsertMode.AFTER)

--- a/src/mr_reduction/script_output.py
+++ b/src/mr_reduction/script_output.py
@@ -18,6 +18,8 @@ import mantid.simpleapi as api
 # mr_reduction imports
 from mr_reduction.reflectivity_output import quicknxs_scaling_factor
 from mr_reduction.runpeak import RunPeakNumber
+from mr_reduction.settings import PolarizationLogs
+from mr_reduction.types import MantidWorkspace
 
 
 def write_reduction_script(matched_runs, scaling_factors, ar_dir) -> str:
@@ -69,7 +71,11 @@ def write_reduction_script(matched_runs, scaling_factors, ar_dir) -> str:
     return script_filepath
 
 
-def write_partial_script(ws_grp, output_dir):
+def write_partial_script(
+    ws_grp: mantid.api.WorkspaceGroup | MantidWorkspace,
+    output_dir: str,
+    polarization_logs: PolarizationLogs | None = None,
+) -> None:
     r"""
     Write a partial python reduction script. This script will be
     used by the merging process to produce a clean and final reduction
@@ -92,7 +98,7 @@ def write_partial_script(ws_grp, output_dir):
         _ws = ws_grp
         _ws_list = [ws_grp]
 
-    script = generate_script_from_ws(_ws_list, group_name=str(ws_grp))
+    script = generate_script_from_ws(_ws_list, group_name=str(ws_grp), polarization_logs=polarization_logs)
     run_number = _ws.getRunNumber()
     peak_number = RunPeakNumber.peak_number_log(_ws)
     runpeak = RunPeakNumber(run_number, peak_number)
@@ -148,7 +154,13 @@ def _insert_relative_to_keyword(
     )
 
 
-def generate_script_from_ws(ws_grp, group_name, quicknxs_mode=True, include_workspace_string=True) -> str:
+def generate_script_from_ws(
+    ws_grp: list | mantid.api.WorkspaceGroup,
+    group_name: str,
+    quicknxs_mode: bool = True,
+    include_workspace_string: bool = True,
+    polarization_logs: PolarizationLogs | None = None,
+) -> str:
     r"""Generate a partial reduction script from a set of workspaces.
 
     This function needs to be compatible with the case of a single workspace.
@@ -171,6 +183,11 @@ def generate_script_from_ws(ws_grp, group_name, quicknxs_mode=True, include_work
         name of the group the workspace belongs to
     quicknxs_mode: bool
         If True, the script will include a scaling factor correction for compatibility with QuickNXS
+    include_workspace_string: bool
+        If True, the script will include a line defining the workspace group
+        (e.g. "workspaces['r_12345_1'] = ['12345_Off_Off__reflectivity', '12345_On_Off__reflectivity']")
+    polarization_logs: PolarizationLogs | None
+        If provided, the script will use the polarization logs definition in the generated script
 
     Returns
     -------
@@ -178,6 +195,10 @@ def generate_script_from_ws(ws_grp, group_name, quicknxs_mode=True, include_work
     """
     if len(ws_grp) == 0:
         return "# No workspace was generated\n"
+
+    if polarization_logs is None:
+        # use the default
+        polarization_logs = PolarizationLogs()
 
     xs_list = [str(_ws) for _ws in ws_grp if not str(_ws).endswith("unfiltered")]
     script = ""
@@ -199,21 +220,25 @@ def generate_script_from_ws(ws_grp, group_name, quicknxs_mode=True, include_work
 
     lines = script_text.split("\n")
 
-    # insert function `split_events` which is not part of the workspace history
-    _insert_relative_to_keyword(
-        lines,
-        "from mantid.simpleapi import *",
-        "from mr_reduction.filter_events import split_events",
-        mode=StringInsertMode.AFTER,
-    )
+    # insert function `split_events` which is not part of the workspace history and required imports
+    imports_snippet = """from mr_reduction.filter_events import split_events
+from mr_reduction.settings import PolarizationLogs"""
+    _insert_relative_to_keyword(lines, "from mantid.simpleapi import *", imports_snippet, mode=StringInsertMode.AFTER)
     _insert_relative_to_keyword(lines, "LoadEventNexus", "ws = ", mode=StringInsertMode.PREPEND)
-    _insert_relative_to_keyword(
-        lines, "ws = LoadEventNexus", "ws_list = split_events(input_workspace=ws)", mode=StringInsertMode.AFTER
-    )
+    polarization_logs_snippet = f'polarization_logs = PolarizationLogs(pol_state="{polarization_logs.POL_STATE}", '
+    polarization_logs_snippet += f'pol_veto="{polarization_logs.POL_VETO}", '
+    polarization_logs_snippet += f'ana_state="{polarization_logs.ANA_STATE}", '
+    polarization_logs_snippet += f'ana_veto="{polarization_logs.ANA_VETO}")'
+    split_events_snippet = f"""{polarization_logs_snippet}
+ws_list = split_events(input_workspace=ws, polarization_logs=polarization_logs)"""
+    _insert_relative_to_keyword(lines, "ws = LoadEventNexus", split_events_snippet, mode=StringInsertMode.AFTER)
 
     # reformat for better readability
+    refl_algo_idx = [i for i, line in enumerate(lines) if "MagnetismReflectometryReduction(" in line]
+    tmp_refl_algo_line = lines[refl_algo_idx[0]].replace(", ", ",\n                                ")
+    lines[refl_algo_idx[0]] = tmp_refl_algo_line
     script_text = "\n".join(lines)
-    script += script_text.replace(", ", ",\n                                ")
+    script += script_text
     script += "\n"
 
     api.logger.notice(f"Script length after formatting {len(script)}")

--- a/src/mr_reduction/settings.py
+++ b/src/mr_reduction/settings.py
@@ -9,22 +9,17 @@ Reduction settings for MR
 # live data lacks PV's "PolarizerState", "PolarizerVeto", "AnalyzerState", and "AnalyzerVeto"
 # so we need to use the short names
 class PolarizationLogs:
-    POL_STATE: str = "SF1"  # a.k.a "PolarizerState"
-    POL_VETO: str = "SF1_Veto"  # a.k.a "PolarizerVeto"
-    ANA_STATE: str = "SF2"  # a.k.a "AnalyzerState"
-    ANA_VETO: str = "SF2_Veto"  # a.k.a "AnalyzerVeto"
-
     def __init__(
         self,
-        pol_state: str = "SF1",
-        pol_veto: str = "SF1_Veto",
-        ana_state: str = "SF2",
-        ana_veto: str = "SF2_Veto",
+        pol_state: str = "SF1",  # a.k.a "PolarizerState"
+        pol_veto: str = "SF1_Veto",  # a.k.a "PolarizerVeto"
+        ana_state: str = "SF2",  # a.k.a "AnalyzerState"
+        ana_veto: str = "SF2_Veto",  # a.k.a "AnalyzerVeto"
     ):
-        self.POL_STATE = pol_state
-        self.POL_VETO = pol_veto
-        self.ANA_STATE = ana_state
-        self.ANA_VETO = ana_veto
+        self.pol_state = pol_state
+        self.pol_veto = pol_veto
+        self.ana_state = ana_state
+        self.ana_veto = ana_veto
 
 
 # Default TOF binning for histograms

--- a/src/mr_reduction/settings.py
+++ b/src/mr_reduction/settings.py
@@ -14,6 +14,18 @@ class PolarizationLogs:
     ANA_STATE: str = "SF2"  # a.k.a "AnalyzerState"
     ANA_VETO: str = "SF2_Veto"  # a.k.a "AnalyzerVeto"
 
+    def __init__(
+        self,
+        pol_state: str = "SF1",
+        pol_veto: str = "SF1_Veto",
+        ana_state: str = "SF2",
+        ana_veto: str = "SF2_Veto",
+    ):
+        self.POL_STATE = pol_state
+        self.POL_VETO = pol_veto
+        self.ANA_STATE = ana_state
+        self.ANA_VETO = ana_veto
+
 
 # Default TOF binning for histograms
 TOF_MIN = 10000

--- a/tests/integration/test_mr_reduction.py
+++ b/tests/integration/test_mr_reduction.py
@@ -31,10 +31,10 @@ class TestReduction:
             output_dir=mock_filesystem.tempdir,
             publish=False,  # don't upload to the livedata server
         )
-        processor.polarization_logs.POL_STATE = "SF1"
-        processor.polarization_logs.ANA_STATE = "SF2"
-        processor.polarization_logs.POL_VETO = ""
-        processor.polarization_logs.ANA_VETO = ""
+        processor.polarization_logs.pol_state = "SF1"
+        processor.polarization_logs.ana_state = "SF2"
+        processor.polarization_logs.pol_veto = ""
+        processor.polarization_logs.ana_veto = ""
         processor.reduce()
         # assert reduction files have been produced
         for file in [
@@ -64,10 +64,10 @@ class TestReduction:
         processor = mr.ReductionProcess(
             data_run=data_server.path_to("REF_M_28142.nxs.h5"), output_dir=mock_filesystem.tempdir
         )
-        processor.polarization_logs.POL_STATE = "SF1"
-        processor.polarization_logs.ANA_STATE = "SF2"
-        processor.polarization_logs.POL_VETO = ""
-        processor.polarization_logs.ANA_VETO = ""
+        processor.polarization_logs.pol_state = "SF1"
+        processor.polarization_logs.ana_state = "SF2"
+        processor.polarization_logs.pol_veto = ""
+        processor.polarization_logs.ana_veto = ""
         processor.reduce()
         # assert reduction files have been produced
         for file in [


### PR DESCRIPTION
## Description of work:

This is a small tweak to the previous PR #122 to make it easier for users to modify the set of PV:s used to split the raw data into polarization cross-sections. 

The polarization logs setup is now included in the generated scripts:

```
ws = LoadEventNexus(Filename='<FILE_PATH>/REF_M_42535.nxs.h5', OutputWorkspace='ws_42535')
polarization_logs = PolarizationLogs(pol_state="SF1", pol_veto="SF1_Veto", ana_state="SF2", ana_veto="SF2_Veto")
ws_list = split_events(input_workspace=ws, polarization_logs=polarization_logs)
```

Check all that apply:
- [ ] Documentation updated
- [x] Source added/refactored
- [x] Unit tests added/refactored
- [ ] Integration tests added/refactored

**References:**
- Links to IBM EWM items: [Defect 14739: [mr_reduction] Python scripts generated during autoreduction are missing cross section filtering](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=14739)
- Links to related issues or pull requests:

## :warning: Manual test for the reviewer
(Instructions for testing here)

On this branch on the analysis cluster:

```
pixi shell
cp /SNS/REF_M/shared/autoreduce/reduce_REF_M.py .
mkdir output
python reduce_REF_M.py /SNS/REF_M/IPTS-31954/nexus/REF_M_42535.nxs.h5 ./output --no_publish
# run the generated combined script (built from the partial scripts) to see that it runs without errors
python output/REF_M_42535_1_combined.py
```

Also inspect the combined Python script to see that the polarization log setup is visible and can be updated.

## Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
