### PR TITLE
Update pixi conda-build task

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -86,10 +86,9 @@ jobs:
       - name: Build conda package
         run: |
           pixi run conda-build
-          mkdir -p ./local-channel/noarch
-          cp *.conda ./local-channel/noarch/
+        
           # extract version from the package file name "quicknxs-<version>-<build>.conda"
-          echo "PKG_VERSION=$(ls *.conda | cut -d'-' -f2)" >> $GITHUB_ENV
+          echo "PKG_VERSION=$(basename local-channel/noarch/*.conda | cut -d '-' -f2)" >> $GITHUB_ENV
 
       - name: Install built conda package
         id: install

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Pixi
-        uses: prefix-dev/setup-pixi@v0.9.6
+        uses: prefix-dev/setup-pixi@v0.10.0
 
       - name: Install chromium
         run: |
@@ -81,14 +81,11 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Setup Pixi
-        uses: prefix-dev/setup-pixi@v0.9.6
+        uses: prefix-dev/setup-pixi@v0.10.0
 
       - name: Build conda package
         run: |
           pixi run conda-build
-        
-          # extract version from the package file name "quicknxs-<version>-<build>.conda"
-          echo "PKG_VERSION=$(basename local-channel/noarch/*.conda | cut -d '-' -f2)" >> $GITHUB_ENV
 
       - name: Install built conda package
         id: install
@@ -137,7 +134,7 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Setup Pixi
-        uses: prefix-dev/setup-pixi@v0.9.6
+        uses: prefix-dev/setup-pixi@v0.10.0
 
       - name: Download conda package artifact
         uses: actions/download-artifact@v8

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -86,8 +86,8 @@ jobs:
       - name: Build conda package
         run: |
           pixi run conda-build
-          mkdir -p /tmp/local-channel/noarch
-          cp *.conda /tmp/local-channel/noarch/
+          mkdir -p ./local-channel/noarch
+          cp *.conda ./local-channel/noarch/
           # extract version from the package file name "quicknxs-<version>-<build>.conda"
           echo "PKG_VERSION=$(ls *.conda | cut -d'-' -f2)" >> $GITHUB_ENV
 
@@ -96,7 +96,7 @@ jobs:
         uses: neutrons/conda-actions/pkg-install@v2
         with:
           package-name: ${{ env.PKG_NAME }}
-          local-channel: /tmp/local-channel
+          local-channel: ./local-channel
           python-version: "3.11"
           extra-channels: neutrons mantid oncat
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,12 @@
+# Auto-generated version file
+src/mr_reduction/_version.py
+
+# build artifacts
+*.conda
+local-channel/
+
+### template ignores
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -158,8 +167,3 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
-
-# Auto-generated version file
-src/mr_reduction/_version.py
-
-*.conda

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,7 +164,7 @@ test-docs = { cmd = "sphinx-build -M doctest docs docs/_build/html", description
 # Testing
 test = { description = "Run the test suite", cmd = "pytest" }
 # Packaging
-conda-build-command = { cmd = "pixi publish --target-channel /tmp/local-channel", description = "Wrapper for building the conda package - used by `conda-build`" }
+conda-build-command = { cmd = "pixi publish --target-channel ./local-channel", description = "Wrapper for building the conda package - used by `conda-build`" }
 conda-build = { description = "Build the conda package", depends-on = [
   "sync-version",
   "conda-build-command",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ name = "mr_reduction"
 version = "0.0.0"
 
 [tool.pixi.package.build]
-backend = { name = "pixi-build-python", version = "0.4.*" }
+backend = { name = "pixi-build-python", version = "*" }
 
 [tool.pixi.package.host-dependencies]
 python = ">=3.11,<3.12"
@@ -164,7 +164,7 @@ test-docs = { cmd = "sphinx-build -M doctest docs docs/_build/html", description
 # Testing
 test = { description = "Run the test suite", cmd = "pytest" }
 # Packaging
-conda-build-command = { cmd = "pixi build", description = "Wrapper for building the conda package - used by `conda-build`" }
+conda-build-command = { cmd = "pixi publish --target-channel /tmp/local-channel", description = "Wrapper for building the conda package - used by `conda-build`" }
 conda-build = { description = "Build the conda package", depends-on = [
   "sync-version",
   "conda-build-command",


### PR DESCRIPTION
Pixi build is deprecated and to be replaced with `pixi publish`, updates `conda-build` pixi task and workflow accordingly